### PR TITLE
Rework _index files. Make getting_started the main tutorial

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -3,23 +3,6 @@ title: WebAssembly
 description: Get an overview over the WebAssembly support
 keywords: WebAssembly
 author: einari
-weight: 2
 repository: https://github.com/dolittle-interaction/WebAssembly
 ---
-{{% notice warning %}}
-WebAssembly support is to be considered experimental.
-Seeing that we have less experience with it than our server side and the fact
-that the underlying Mono support for WebAssembly being used is still in test
-stages, you're at your own risk.
-
-However, that being said - we have so far had good experience with it on projects
-we've used, we just need a bit more time with it.
-{{% /notice %}}
-
-To get started with Dolittle and the WebAssembly support, read our
-[getting started guide](./getting_started).
-
-If you want to get a video walkthrough, have a look below:
-
-{{< youtube XsOxFaXoxxs >}}
 

--- a/Documentation/getting_started.md
+++ b/Documentation/getting_started.md
@@ -1,10 +1,23 @@
 ---
 title: Getting started
+url: /interaction/webassembly/
 description: Get started with Dolittle WebAssembly support
 keywords: WebAssembly, Getting Started
 author: einari
-weight: 3
+weight: 1
+aliases:
+    - /interaction/webassembly/getting_started/
 ---
+
+{{% notice warning %}}
+WebAssembly support is to be considered experimental.
+Seeing that we have less experience with it than our server side and the fact
+that the underlying Mono support for WebAssembly being used is still in test
+stages, you're at your own risk. However, that being said - we have so far had good experience with it on projects
+we've used, we just need a bit more time with it.
+{{% /notice %}}
+
+
 This section describes how you can get started with the Dolittle WebAssembly support.
 If you're looking for a finished sample with everything set up, you can go [here](https://github.com/dolittle-samples/ToDolittle).
 
@@ -33,6 +46,10 @@ our [walktrough](https://dolittle.io/getting-started/gettingstarted/), as this g
 
 For the time being, we don't have [boilerplates](http://github.com/dolittle-boilerplates) for WebAssembly, and
 that means we need to do a bit more manual work to get started.
+
+If you want to get a video walkthrough, have a look below:
+
+{{< youtube XsOxFaXoxxs >}}
 
 ## .NET Core
 


### PR DESCRIPTION
As there are 2 clashing tutorials here , getting_started and
simplest_thing I decided to make getting_started the main one as it has
a proper name to it.

In the future these things should go to dolittle/Learning probably as they are tutorials and kinda separated from the code.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1159178788163598)
